### PR TITLE
Call the theme lib file

### DIFF
--- a/config.php
+++ b/config.php
@@ -25,6 +25,8 @@
 // This line protects the file from being accessed by a URL directly.
 defined('MOODLE_INTERNAL') || die();
 
+require_once(__DIR__ . '/lib.php');
+
 // $THEME is defined before this page is included and we can define settings by adding properties to this global object.
 
 // The first setting we need is the name of the theme. This should be the last part of the component name, and the same


### PR DESCRIPTION
I had difficulty extending the "classes" folder by not calling the lib.php file in the config.php file. Nothing in documentation official.

I suggest the file be call by default

Thanks